### PR TITLE
去掉使用 boss-group 和 worker-group 时的 warning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.32.Final")
+(def netty-version "4.1.34.Final")
 
 (def example-base-command
   ["trampoline" "with-profile" "default,example" "run" "-m"])
@@ -8,7 +8,7 @@
   :url "http://github.com/sunng87/link"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [io.netty/netty-buffer ~netty-version]
                  [io.netty/netty-codec-http ~netty-version]
                  [io.netty/netty-codec-http2 ~netty-version]

--- a/src/link/tcp.clj
+++ b/src/link/tcp.clj
@@ -5,8 +5,8 @@
   (:import [java.net InetAddress InetSocketAddress]
            [io.netty.bootstrap Bootstrap ServerBootstrap]
            [io.netty.channel ChannelInitializer Channel ChannelHandler
-                             ChannelFuture EventLoopGroup
-                             ChannelPipeline ChannelOption]
+            ChannelFuture EventLoopGroup
+            ChannelPipeline ChannelOption]
            [io.netty.channel.nio NioEventLoopGroup]
            [io.netty.channel.socket.nio
             NioServerSocketChannel NioSocketChannel]

--- a/src/link/tcp.clj
+++ b/src/link/tcp.clj
@@ -5,13 +5,15 @@
   (:import [java.net InetAddress InetSocketAddress]
            [io.netty.bootstrap Bootstrap ServerBootstrap]
            [io.netty.channel ChannelInitializer Channel ChannelHandler
-            ChannelFuture EventLoopGroup
-            ChannelPipeline ChannelOption]
+                             ChannelFuture EventLoopGroup
+                             ChannelPipeline ChannelOption]
            [io.netty.channel.nio NioEventLoopGroup]
            [io.netty.channel.socket.nio
             NioServerSocketChannel NioSocketChannel]
-           [io.netty.util.concurrent EventExecutorGroup]
-           [link.core ClientSocketChannel]))
+           [io.netty.util.concurrent EventExecutorGroup DefaultThreadFactory]
+           [link.core ClientSocketChannel]
+           (io.netty.util.internal SystemPropertyUtil)
+           (io.netty.util NettyRuntime)))
 
 (defn to-channel-option
   ([co]
@@ -67,14 +69,26 @@
               :else
               (append-handlers->pipeline pipeline [h]))))))))
 
+(defn- default-nio-boss-group []
+  (let [group (NioEventLoopGroup. 1 (DefaultThreadFactory. "link-nio-boss-group"))]
+    (.setIoRatio group 100)
+    group))
+
+(defn- default-nio-worker-group []
+  (NioEventLoopGroup. (max 1 (SystemPropertyUtil/getInt "io.netty.eventLoopThreads"
+                                                        (* 2 (NettyRuntime/availableProcessors))))
+                      (DefaultThreadFactory. "link-nio-worker-group")))
+
 (defn- start-tcp-server [host port handlers options]
-  (let [boss-group (or (:boss-group options) (NioEventLoopGroup.))
-        worker-group (or (:worker-group options) (NioEventLoopGroup.))
+  (let [boss-group (or (:boss-group options) (default-nio-boss-group))
+        worker-group (or (:worker-group options) (default-nio-worker-group))
         bootstrap (or (:bootstrap options) (ServerBootstrap.))
 
         channel-initializer (channel-init handlers)
 
-        options (group-by #(.startsWith (name (% 0)) "child.") (into [] options))
+        options (->> (dissoc options :boss-group :worker-group :bootstrap)
+                     (into [])
+                     (group-by #(.startsWith (name (% 0)) "child.")))
         parent-options (get options false)
         child-options (map #(vector (keyword (subs (name (% 0)) 6)) (% 1)) (get options true))]
     (doto bootstrap
@@ -113,14 +127,14 @@
   "Allow multiple server instance share the same eventloop:
   Just use the result of this function as option in `tcp-server`"
   []
-  {:boss-group (NioEventLoopGroup.)
-   :worker-group (NioEventLoopGroup.)
+  {:boss-group (default-nio-boss-group)
+   :worker-group (default-nio-worker-group)
    :boostrap (ServerBootstrap.)})
 
 (defn tcp-client-factory [handlers
                           & {:keys [options]
                              :or {options {}}}]
-  (let [worker-group (NioEventLoopGroup.)
+  (let [worker-group (or (:worker-group options) (default-nio-worker-group))
         bootstrap (Bootstrap.)
         handlers (cond
                    (fn? handlers) handlers
@@ -128,13 +142,14 @@
                    :else [handlers])
 
         channel-initializer (channel-init handlers)
-        options (into [] options)]
+        options (->> (dissoc options :worker-group)
+                     (into []))]
 
     (doto bootstrap
       (.group worker-group)
       (.channel NioSocketChannel)
       (.handler channel-initializer))
-    (doseq [op (into [] options)]
+    (doseq [op options]
       (let [op (flatten op)]
         (.option bootstrap (apply to-channel-option (butlast op)) (last op))))
 

--- a/src/link/threads.clj
+++ b/src/link/threads.clj
@@ -6,7 +6,7 @@
   ([threads] (DefaultEventExecutorGroup. threads))
   ([threads thread-factory] (DefaultEventExecutorGroup. threads thread-factory)))
 
-(defn prefix-thread-factory [name-prefix]
+(defn ^ThreadFactory prefix-thread-factory [name-prefix]
   (let [counter (atom 0)]
     (reify ThreadFactory
       (newThread [this r]


### PR DESCRIPTION
使用 :boss-group 和 :worker-group 参数创建 tcp-server 时候会有两个 warning:
```
16:26:31.072 [1 main] WARN  io.netty.bootstrap.ServerBootstrap - Unknown channel option 'WORKER_GROUP' for channel '[id: 0x0275f304]'
16:26:31.072 [1 main] WARN  io.netty.bootstrap.ServerBootstrap - Unknown channel option 'BOSS_GROUP' for channel '[id: 0x0275f304]'
```